### PR TITLE
Exercise Updates

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,7 @@ services:
         volumes:
             - /var/lib/postgresql/data
         healthcheck:
-            test: psql --username lightside -c "SELECT COUNT(1) FROM pg_catalog.pg_roles;"
+            test: psql --username postgres -c "SELECT COUNT(1) FROM pg_catalog.pg_roles;"
             interval: 30s
             timeout: 10s
             retries: 3

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ version: "2.1"
 services:
     postgres:
         container_name: postgres
-        image: postgres-alpine:9.6
+        image: postgres:9.6-alpine
         ports:
             - 5432:5432
         volumes:


### PR DESCRIPTION
From manda - `lightside` still in healthcheck, postgres container image is incorrect.